### PR TITLE
Here's my x86_64 and linux optimisations. Hopefully shouldn't break other OSs now.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+- Linux x86_64 optimisations - Con Kolivas
+- Optimise for x86_64 by default by using sse2_64 algo
+- Detects CPUs and sets number of threads accordingly
+- Uses CPU affinity for each thread where appropriate
+- Sets scheduling policy to lowest possible
+- Minor performance tweaks
 
 Version 1.0.1 - May 14, 2011
 

--- a/miner.h
+++ b/miner.h
@@ -87,12 +87,14 @@ enum {
 };
 #endif
 
+#undef unlikely
+#undef likely
 #if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
-#undef unlikely
-#define unlikely(expr) (__builtin_expect((expr), 0))
+#define unlikely(expr) (__builtin_expect(!!(expr), 0))
+#define likely(expr) (__builtin_expect(!!(expr), 1))
 #else
-#undef unlikely
 #define unlikely(expr) (expr)
+#define likely(expr) (expr)
 #endif
 
 #if defined(__i386__)

--- a/sha256_sse2_amd64.c
+++ b/sha256_sse2_amd64.c
@@ -100,13 +100,13 @@ int scanhash_sse2_64(int thr_id, const unsigned char *pmidstate,
 
 	for (j = 0; j < 4; j++) {
 	    mi.m = m_4hash[7];
-	    if (mi.i[j] == 0)
+	    if (unlikely(mi.i[j] == 0))
 		break;
         }
 
 	/* If j = true, we found a hit...so check it */
 	/* Use the C version for a check... */
-	if (j != 4) {
+	if (unlikely(j != 4)) {
 		for (i = 0; i < 8; i++) {
 		    mi.m = m_4hash[i];
 		    *(uint32_t *)&(phash)[i*4] = mi.i[j];
@@ -121,12 +121,12 @@ int scanhash_sse2_64(int thr_id, const unsigned char *pmidstate,
 
 	nonce += 4;
 
-        if ((nonce >= max_nonce) || work_restart[thr_id].restart)
+        if (unlikely((nonce >= max_nonce) || work_restart[thr_id].restart))
         {
             *nHashesDone = nonce;
             return -1;
-        }
-    }
+	}
+   }
 }
 
 #endif /* WANT_X8664_SSE2 */


### PR DESCRIPTION
Add likely() macro.
Optimise a few obvious code paths with likely/unlikely.
Change algo to sse2_amd64 by default.
Move priority change to worker threads only.
Detect number of CPUs and set default number of threads == CPUs.
Add scheduling policy change to worker threads to SCHED_IDLE first and fallback to SCHED_BATCH on linux.
Don't error when failing to set priority.
Add CPU affinity and bind worker threads to CPUs when number of threads is a multiple of number of CPUs.
Update NEWS with changes.
