### PR TITLE
add linux/sched.h include for SCHED_IDLE

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -36,6 +36,7 @@
 
 #ifdef __linux /* Linux specific policy and affinity management */
 #include <sched.h>
+#include <linux/sched.h>
 static inline void drop_policy(void)
 {
 	struct sched_param param;


### PR DESCRIPTION
this fixes compilation on Linux (at least openSUSE 11.4)
Signed-off-by: Bernhard M. Wiedemann <bernhard+btcgit lsmod de>
