### PR TITLE
Implement total throughput and solutions counters and improve output.

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -40,8 +40,12 @@ static inline void drop_policy(void)
 {
 	struct sched_param param;
 
+#ifdef SCHED_IDLE
 	if (unlikely(sched_setscheduler(0, SCHED_IDLE, &param) == -1))
+#endif
+#ifdef SCHED_BATCH
 		sched_setscheduler(0, SCHED_BATCH, &param);
+#endif
 }
 
 static inline void affine_to_cpu(int id, int cpu)


### PR DESCRIPTION
Add a solution counter to the output.
Implement global hash rate counter through mutex lock protected data.
Make the output easier to read.
Don't do hashmeter updates if no output is requested.
Remove redundant output when using a single thread.
