### PR TITLE
Remove extra parameter from scanhash_asm32.

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -628,7 +628,7 @@ static void *miner_thread(void *userdata)
 #ifdef WANT_CRYPTOPP_ASM32
 		case ALGO_CRYPTOPP_ASM32:
 			rc = scanhash_asm32(thr_id, work.midstate, work.data + 64,
-				        work.hash1, work.hash, work.target,
+				        work.hash, work.target,
 					max_nonce, &hashes_done);
 			break;
 #endif

--- a/miner.h
+++ b/miner.h
@@ -164,7 +164,7 @@ extern bool scanhash_cryptopp(int, const unsigned char *midstate,unsigned char *
 	      unsigned char *hash, const unsigned char *target,
 	      uint32_t max_nonce, unsigned long *hashes_done);
 extern bool scanhash_asm32(int, const unsigned char *midstate,unsigned char *data,
-	      unsigned char *hash1, unsigned char *hash,
+	      unsigned char *hash,
 	      const unsigned char *target,
 	      uint32_t max_nonce, unsigned long *hashes_done);
 extern int scanhash_sse2_64(int, const unsigned char *pmidstate, unsigned char *pdata,


### PR DESCRIPTION
This `unsigned char *hash1` was preventing compilation on ia32 systems and
it seems to be (apparently) unneeded according to my tests.

This fixes #41.

Signed-off-by: Rogério Brito rbrito@ime.usp.br
